### PR TITLE
Fix issue when listing daemonset pods

### DIFF
--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -250,10 +250,10 @@ func (h *Handler) getDaemonsetPods(ctx context.Context, nodeName string, ds Daem
 	}
 
 	matchingPods := make([]*corev1.Pod, 0)
-	for _, pod := range pods.Items {
+	for i, pod := range pods.Items {
 		for _, owner := range pod.OwnerReferences {
 			if owner.Name == ds.Name && pod.Spec.NodeName == nodeName {
-				matchingPods = append(matchingPods, &pod)
+				matchingPods = append(matchingPods, &pods.Items[i])
 			}
 		}
 	}


### PR DESCRIPTION
This should fix this [issue](#18) where the same pod ref keeps being added to the list of matching pods instead of the ref of each different pod matching the criteria.

Closes #18 