### PR TITLE
fix(badges): Fix GH workflow badges in docs/README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
-![main](https://github.com/pelotech/nidhogg/actions/workflows/main.yaml/badge.svg)
-![pre-commit](https://github.com/pelotech/nidhogg/actions/workflows/pre-commit.yaml/badge.svg)
+![build](https://github.com/pelotech/nidhogg/actions/workflows/build.yaml/badge.svg)
+![release](https://github.com/pelotech/nidhogg/actions/workflows/release.yaml/badge.svg)
 ![publish-chart](https://github.com/pelotech/nidhogg/actions/workflows/publish-chart.yaml/badge.svg)
 
 # Nidhogg


### PR DESCRIPTION
This fixes the badges in `docs/README.md` after renaming the Github workflows