### PR TITLE
chore: release nidhogg Helm chart for version v0.5.3

### DIFF
--- a/.github/workflows/publish-chart.yaml
+++ b/.github/workflows/publish-chart.yaml
@@ -24,7 +24,7 @@ jobs:
         with:
           name: nidhogg
           repository: pelotech/charts
-          tag: 0.1.0
+          tag: v0.5.3
           registry: ghcr.io
           registry_username: ${{ github.actor }}
           registry_password: ${{ secrets.github_token }}

--- a/charts/nidhogg/Chart.yaml
+++ b/charts/nidhogg/Chart.yaml
@@ -2,5 +2,4 @@ apiVersion: v2
 name: nidhogg
 description: A Helm chart for Kubernetes
 type: application
-version: 0.1.0
-appVersion: "v0.5.0"
+version: v0.5.3

--- a/charts/nidhogg/README.md
+++ b/charts/nidhogg/README.md
@@ -1,6 +1,6 @@
 # nidhogg
 
-![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0](https://img.shields.io/badge/AppVersion-v0.5.0-informational?style=flat-square)
+![Version: v0.5.3](https://img.shields.io/badge/Version-v0.5.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 A Helm chart for Kubernetes
 

--- a/charts/nidhogg/templates/_helpers.tpl
+++ b/charts/nidhogg/templates/_helpers.tpl
@@ -36,9 +36,7 @@ Common labels
 {{- define "nidhogg.labels" -}}
 helm.sh/chart: {{ include "nidhogg.chart" . }}
 {{ include "nidhogg.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+app.kubernetes.io/version: {{ .Chart.Version | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 

--- a/charts/nidhogg/templates/statefulset.yaml
+++ b/charts/nidhogg/templates/statefulset.yaml
@@ -32,7 +32,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.Version }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /manager

--- a/charts/nidhogg/values.yaml
+++ b/charts/nidhogg/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 2
 image:
   repository: ghcr.io/pelotech/nidhogg
   pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
+  # Overrides the image tag whose default is the chart Version.
   tag: ""
 
 imagePullSecrets: []


### PR DESCRIPTION
Hardcoding chart version/app_version for `v0.5.3` to release chart

Next release we will automate version bump automatically when releasing a new version