### PR TITLE
chore: switch kustomize to use v0.5.3

### DIFF
--- a/kustomize/resources.yaml
+++ b/kustomize/resources.yaml
@@ -45,7 +45,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: ghcr.io/pelotech/nidhogg:v0.5.1
+        image: ghcr.io/pelotech/nidhogg:v0.5.3
         imagePullPolicy: IfNotPresent
         name: manager
         args:


### PR DESCRIPTION
Bumping kustomize to use version`v0.5.3` from now on