### PR TITLE
chore(chart): add extra labels to statefulset

### DIFF
--- a/charts/nidhogg/README.md
+++ b/charts/nidhogg/README.md
@@ -12,6 +12,7 @@ A Helm chart for Kubernetes
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
 | configuration | object | `{"taintRemovalDelayInSeconds":5}` | Configuration for nidhogg |
+| extraLabels | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/pelotech/nidhogg"` |  |

--- a/charts/nidhogg/templates/statefulset.yaml
+++ b/charts/nidhogg/templates/statefulset.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "nidhogg.fullname" . }}
   labels:
     {{- include "nidhogg.labels" . | nindent 4 }}
+    {{- with .Values.extraLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/charts/nidhogg/values.yaml
+++ b/charts/nidhogg/values.yaml
@@ -35,6 +35,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+# StatefulSet additional labels
+extraLabels: {}
 podAnnotations: {}
 podLabels: {}
 


### PR DESCRIPTION
hello pelotch members,

Thank you for maintaining this excellent project

This PR introduces extralLabels for statefulset  to enable [kube-state-metrics](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/workload/statefulset-metrics.md)  to delivery kube_statefulset_labels with custom labels.

Please let me know anything can be improved in this PR.