### PR TITLE
fix: remove log message about missing/unknown taint effect (#98)

### DIFF
--- a/pkg/nidhogg/handler.go
+++ b/pkg/nidhogg/handler.go
@@ -282,7 +282,6 @@ func (h *Handler) getTaintEffect() corev1.TaintEffect {
 	case "NoExecute":
 		effect = corev1.TaintEffectNoExecute
 	default:
-		logf.Log.Info("Missing/unknown taint effect, defaulting to NoSchedule", "taintEffect", h.config.TaintEffect)
 		effect = corev1.TaintEffectNoSchedule
 	}
 


### PR DESCRIPTION
Proposing to remove this default log message as it is causing a lot of these log lines to be logged and they are currently not useful and it is impacting our logging platform as we have a lot of nodes.

Please see the issue for additional information.